### PR TITLE
chore: update dependencies and fix clippy warning

### DIFF
--- a/temps-core/Cargo.toml
+++ b/temps-core/Cargo.toml
@@ -9,8 +9,8 @@ readme = "../README.md"
 license.workspace = true
 
 [dependencies]
-winnow = "0.7.12"
-thiserror = "2.0"
+winnow = "0.7.13"
+thiserror = "2.0.16"
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/temps-jiff/src/lib.rs
+++ b/temps-jiff/src/lib.rs
@@ -138,10 +138,10 @@ impl TimeParser for JiffProvider {
                         ));
                     }
                     // Validate second is in valid range (0-59)
-                    if let Some(second) = abs.second {
-                        if second > 59 {
-                            return Err(TempsError::invalid_time(hour, minute, second));
-                        }
+                    if let Some(second) = abs.second
+                        && second > 59
+                    {
+                        return Err(TempsError::invalid_time(hour, minute, second));
                     }
 
                     let time = Time::new(

--- a/temps/Cargo.toml
+++ b/temps/Cargo.toml
@@ -29,5 +29,5 @@ temps-chrono = { path = "../temps-chrono", version = "2.0.1", optional = true }
 temps-jiff = { path = "../temps-jiff", version = "2.0.1", optional = true }
 
 [dev-dependencies]
-chrono = "0.4"
-jiff = "0.2"
+chrono = "0.4.41"
+jiff = "0.2.15"


### PR DESCRIPTION
This PR updates all external dependencies to the latest versions found via `cargo search` and fixes a clippy warning.

Changes:
- temps-core: winnow -> 0.7.13, thiserror -> 2.0.16
- temps (dev-deps): chrono = 0.4.41, jiff = 0.2.15
- temps-jiff: collapse nested `if` for second validation per clippy

Verification:
- Ran `just check` (fmt, clippy, tests, doc-tests, examples): all pass cleanly.